### PR TITLE
Fix the error when hovering over the default website

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -10,7 +10,7 @@ function App() {
   const [show, setShow] = useState(false);
   const [fetchError, setFetchError] = useState('');
 
-  const handleSubmit = (url, width, height) => {
+  const loadURL = (url, width, height) => {
     setShow(true);
     fetch(`http://127.0.0.1:3001/website?url=${url}&width=${width}&height=${height}`)
       .then(async response => {
@@ -49,8 +49,8 @@ function App() {
       </Layer>
 
       <div className="App">
-        <Nav handleSubmit={handleSubmit} fetchError={fetchError}/>
-        <Viewer res={response} />
+        <Nav handleSubmit={loadURL} fetchError={fetchError}/>
+        <Viewer res={response} loadURL={loadURL} />
       </div>
     </div>
   );

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -25,7 +25,7 @@ function App() {
       })
       .catch(err => {
         setShow(false);
-        setFetchError(err);
+        setFetchError('Trouble fetching the URL, please make sure the server is running. `cd server && npm start`');
       });
   };
 

--- a/client/src/components/viewer/Viewer.js
+++ b/client/src/components/viewer/Viewer.js
@@ -40,7 +40,7 @@ const Viewer = ({ res, loadURL }) => {
       setHTMLModule(htmlModule);
 
       loadURL(
-        `https://www.pdftron.com/api/web/global.html`,
+        `https://www.pdftron.com/`,
         1800,
         1100
       );

--- a/client/src/components/viewer/Viewer.js
+++ b/client/src/components/viewer/Viewer.js
@@ -3,7 +3,7 @@ import { initializeHTMLViewer } from '@pdftron/webviewer-html';
 import { useEffect, useRef, useState } from 'react';
 import './Viewer.css';
 
-const Viewer = ({ res }) => {
+const Viewer = ({ res, loadURL }) => {
   const viewer = useRef(null);
   const [HTMLModule, setHTMLModule] = useState(null);
 
@@ -39,16 +39,11 @@ const Viewer = ({ res }) => {
 
       setHTMLModule(htmlModule);
 
-      htmlModule.loadHTMLPages({
-        htmlPages: [
-          {
-            url:
-              'https://www.google.com/maps/embed?pb=!1m14!1m12!1m3!1d41656.714956835!2d-123.0850416!3d49.26607539999999!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.  1!5e0!3m2!1sen!2sca!4v1591640645684!5m2!1sen!2sca',
-            width: 1800,
-            height: 1100,
-          }
-        ],
-      });
+      loadURL(
+        `https://www.pdftron.com/api/web/global.html`,
+        1800,
+        1100
+      );
     });
   }, []);
 


### PR DESCRIPTION
Issue:
- `iframe access` error thrown when hovering over the default loaded web page.

FIx:
- Use the `website-scraper` also for the default website

TODO;
- Find a URL that works with `website-scraper` and also meets the requirement for demo.
- Update version of `WebViewer-html` after https://github.com/XodoDocs/WebViewer-html/pull/5 is merged